### PR TITLE
Delete ModOptions.json

### DIFF
--- a/ModOptions.json
+++ b/ModOptions.json
@@ -1,1 +1,0 @@
-{lastUpdated:2023-03-06T07:00:20Z,modUrl:"https://github.com/Jimmerslock/Undsc-Expansion-Alpha-Frontier",author:Jim_,modSize:676,topics:[unciv-mod,unciv-mod-modsofmods],constants:{unitUpgradeCost:{}}}


### PR DESCRIPTION
newest unciv version throws a red error if this isn't deleted